### PR TITLE
优化样式，window tools 增加 icon，优化下载按钮 loading 时的样式；

### DIFF
--- a/src/components/footer/Footer.vue
+++ b/src/components/footer/Footer.vue
@@ -8,9 +8,8 @@
           @click="download"
           :disabled="currMp3Url == ''"
           :loading="isLoading"
-        >
-          <el-icon><Download /></el-icon>
-        </el-button>
+          :icon="Download"
+        />
       </div>
       <div class="paly-bar-process">
         <audio
@@ -28,6 +27,7 @@
 <script setup lang="ts">
 import { useTtsStore } from "@/store/store";
 import { storeToRefs } from "pinia";
+import { Download } from '@element-plus/icons-vue';
 
 const ttsStore = useTtsStore();
 const { config, currMp3Url, isLoading, audioPlayer } = storeToRefs(ttsStore);

--- a/src/components/header/Header.vue
+++ b/src/components/header/Header.vue
@@ -8,22 +8,25 @@
         class="circle-btn"
         @click="ipcRenderer.send('close')"
       >
+        <el-icon><Close /></el-icon>
       </el-button>
       <el-button
         type="warning"
         size="small"
         circle
         class="circle-btn"
-        @click="ipcRenderer.send('window-maximize')"
+        @click="ipcRenderer.send('min')"
       >
+        <el-icon><Minus /></el-icon>
       </el-button>
       <el-button
         type="success"
         size="small"
         circle
         class="circle-btn"
-        @click="ipcRenderer.send('min')"
+        @click="ipcRenderer.send('window-maximize')"
       >
+        <el-icon><FullScreen /></el-icon>
       </el-button>
     </div>
     <Logo />
@@ -51,9 +54,6 @@ const test = () => {
 }
 .win-tools {
   margin-left: 10px;
-}
-.circle-btn {
-  width: 15px !important;
-  height: 15px !important;
+  transform: scale(0.8);
 }
 </style>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
windows tools 类似 Mac 上的窗口操作，目前缺少 icon，增加了 icon。黄色是最小化，绿色是放大，之前是反了，修正过来了。
语音文件下载的按钮，如果 loading 的时候，会在 下载 icon 前面增加 loading 的 icon，样子很怪，改成现在的，loading 的时候 loading icon 会替换掉 download icon

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
