### PR TITLE
fix: error desktop path

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -160,3 +160,8 @@ ipcMain.on("openDevTools", async (event, arg) => {
     win.webContents.openDevTools({ mode: "undocked", activate: true });
   }
 });
+
+// Get desktop path
+ipcMain.on("getDesktopPath", async (event) => {
+  event.returnValue = app.getPath("desktop");
+});

--- a/src/global/initLocalStore.ts
+++ b/src/global/initLocalStore.ts
@@ -1,7 +1,6 @@
 const Store = require("electron-store");
 const store = new Store();
-const homeDir = require("os").homedir();
-const desktopDir = require("path").resolve(homeDir, "Desktop");
+const { ipcRenderer } = require("electron");
 export default function initStore() {
   if (!store.has("FormConfig.默认")) {
     store.set("FormConfig.默认", {
@@ -14,7 +13,7 @@ export default function initStore() {
     });
   }
   if (!store.has("savePath")) {
-    store.set("savePath", desktopDir);
+    store.set("savePath", ipcRenderer.sendSync("getDesktopPath"));
   }
   if (!store.has("audition")) {
     store.set(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- fix issue in `tsconfig`
  > Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.

- fix: error desktop path
  > use [`getPath`](https://www.electronjs.org/zh/docs/latest/api/app#appgetpathname) instead of stitching Desktop paths
  > ⚠️ ONLY test in Windows (cross-platform support in theoretical)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
